### PR TITLE
Hide rich presence when the game is closed

### DIFF
--- a/titanfall2-rp/PresenceUpdateThread.cs
+++ b/titanfall2-rp/PresenceUpdateThread.cs
@@ -69,6 +69,9 @@ namespace titanfall2_rp
                         ProcessOpenWaitTimeInMinutes);
                     // Set the timer to wait longer
                     presenceUpdateTimer!.Interval = ProcessOpenWaitTimeInMinutes * 60 * 1000;
+                    // Clearing the current presence. This should be fine to call every minute or so.
+                    // The purpose of this is to clear the status if the game closes.
+                    _discordRpcClient.ClearPresence();
                 }
                 else
                 {


### PR DESCRIPTION
When the game is closed, the presence simply stops getting updated. Instead, it should be cleared entirely.

This logs an error to the console (see Lachee/discord-rpc-csharp#155) but this only occurs once so it's not going to flood the logs.