### PR TITLE
Show equipped titan

### DIFF
--- a/TF2.CT
+++ b/TF2.CT
@@ -208,7 +208,6 @@
     <CheatEntry>
       <ID>47</ID>
       <Description>"UPDATE: Neither of these were the current tick number"</Description>
-      <LastState Value="" RealAddress="00000000"/>
       <GroupHeader>1</GroupHeader>
       <CheatEntries>
         <CheatEntry>
@@ -228,7 +227,6 @@
     <CheatEntry>
       <ID>77</ID>
       <Description>"Potential current tick values. Look for increments of 20 or 60 per second"</Description>
-      <LastState Value="" RealAddress="00000000"/>
       <GroupHeader>1</GroupHeader>
       <CheatEntries>
         <CheatEntry>
@@ -302,7 +300,6 @@
     <CheatEntry>
       <ID>78</ID>
       <Description>"These ones set themselves to 1 when the match gets out"</Description>
-      <LastState Value="" RealAddress="00000000"/>
       <GroupHeader>1</GroupHeader>
       <CheatEntries>
         <CheatEntry>
@@ -352,7 +349,6 @@
     <CheatEntry>
       <ID>79</ID>
       <Description>"These ones set themselves to 0 when the match gets out"</Description>
-      <LastState Value="" RealAddress="00000000"/>
       <GroupHeader>1</GroupHeader>
       <CheatEntries>
         <CheatEntry>
@@ -384,7 +380,6 @@
     <CheatEntry>
       <ID>80</ID>
       <Description>"These ones seem to be incrementing by 20"</Description>
-      <LastState Value="" RealAddress="00000000"/>
       <GroupHeader>1</GroupHeader>
       <CheatEntries>
         <CheatEntry>
@@ -438,7 +433,7 @@
     </CheatEntry>
     <CheatEntry>
       <ID>84</ID>
-      <Description>"Currently equpped titan (engine.dll+7A7429)"</Description>
+      <Description>"Currently equipped titan (engine.dll+7A7429)"</Description>
       <VariableType>Byte</VariableType>
       <Address>engine.dll+7A7429</Address>
     </CheatEntry>

--- a/titanfall2-rp/GameDetailsProvider.cs
+++ b/titanfall2-rp/GameDetailsProvider.cs
@@ -24,12 +24,13 @@ namespace titanfall2_rp
             string gameDetails = tf2Api.GetGameMode().ToFriendlyString();
             string gameState = $"{mpStats.GetTeam1Score()}:{mpStats.GetTeam2Score()}";
             var timestamps = new Timestamps(gameOpenTimestamp);
+            var playerInTitan = tf2Api.IsPlayerInTitan();
             var assets = new Assets
             {
                 LargeImageKey = tf2Api.GetMultiplayerMapName(),
                 LargeImageText = tf2Api.GetFriendlyMapName(),
-                SmallImageKey = tf2Api.GetMultiPlayerGameStats().GetCurrentFaction().GetAssetName(),
-                SmallImageText = tf2Api.GetMultiPlayerGameStats().GetCurrentFaction().ToFriendlyString(),
+                SmallImageKey = playerInTitan ? tf2Api.GetTitan().GetAssetName() : tf2Api.GetMultiPlayerGameStats().GetCurrentFaction().GetAssetName(),
+                SmallImageText = playerInTitan ? tf2Api.GetTitan().ToFriendlyString():tf2Api.GetMultiPlayerGameStats().GetCurrentFaction().ToFriendlyString(),
             };
             return (gameDetails, gameState, timestamps, assets);
         }

--- a/titanfall2-rp/GameDetailsProvider.cs
+++ b/titanfall2-rp/GameDetailsProvider.cs
@@ -30,7 +30,7 @@ namespace titanfall2_rp
                 LargeImageKey = tf2Api.GetMultiplayerMapName(),
                 LargeImageText = tf2Api.GetFriendlyMapName(),
                 SmallImageKey = playerInTitan ? tf2Api.GetTitan().GetAssetName() : tf2Api.GetMultiPlayerGameStats().GetCurrentFaction().GetAssetName(),
-                SmallImageText = playerInTitan ? tf2Api.GetTitan().ToFriendlyString():tf2Api.GetMultiPlayerGameStats().GetCurrentFaction().ToFriendlyString(),
+                SmallImageText = playerInTitan ? tf2Api.GetTitan().ToFriendlyString() : tf2Api.GetMultiPlayerGameStats().GetCurrentFaction().ToFriendlyString(),
             };
             return (gameDetails, gameState, timestamps, assets);
         }

--- a/titanfall2-rp/Titanfall2API.cs
+++ b/titanfall2-rp/Titanfall2API.cs
@@ -32,6 +32,51 @@ namespace titanfall2_rp
             return _sharp!.Memory.Read<int>(EngineDllBaseAddress + 0x1122A8DC);
         }
 
+        /// <summary>
+        /// Here's the list of addresses that all reflected the pilot being inside a titan:
+        /// engine.dll+111E18DC
+        /// engine.dll+111E18E0
+        /// engine.dll+111E1CB8
+        /// engine.dll+111E1D10
+        /// engine.dll+111E1D34
+        /// engine.dll+111E1DAC
+        /// engine.dll+111E1DB8
+        /// engine.dll+111E1DC4
+        /// engine.dll+1128D850
+        /// engine.dll+112910F4
+        /// client.dll+21720D7
+        /// client.dll+22BFEC9
+        /// client.dll+22BFED5
+        /// client.dll+22BFEE5
+        /// client.dll+22BFF01
+        /// client.dll+22BFF0D
+        /// client.dll+22BFF1D
+        /// client.dll+22BFF39
+        /// client.dll+22BFF45
+        /// client.dll+22BFF55
+        /// client.dll+22C75E5
+        /// client.dll+22C7605
+        /// client.dll+22C7780
+        /// client.dll+22C78A0
+        /// client.dll+23F5B48
+        /// client.dll+23F5B68
+        /// client.dll+23F5B88
+        /// client.dll+23F5BA8
+        /// client.dll+23F5BC8
+        /// client.dll+23F5BE8
+        /// client.dll+23F5C08
+        /// client.dll+23F5C28
+        /// client.dll+23F5C48
+        /// materialsystem_dx11.dll+1A98090
+        /// </summary>
+        /// <returns>true if the pilot is in a titan; else false</returns>
+        /// <remarks>This shit ain't stable, chief</remarks>
+        public bool IsPlayerInTitan()
+        {
+            _ensureInit();
+            return _sharp!.Memory.Read<int>(_engineDllBaseAddress + 0x111E18DC) != 0;
+        }
+
         public int GetPlayerVelocity()
         {
             _ensureInit();

--- a/titanfall2-rp/Titanfall2API.cs
+++ b/titanfall2-rp/Titanfall2API.cs
@@ -74,13 +74,13 @@ namespace titanfall2_rp
         public bool IsPlayerInTitan()
         {
             _ensureInit();
-            return _sharp!.Memory.Read<int>(_engineDllBaseAddress + 0x111E18DC) != 0;
+            return _sharp!.Memory.Read<int>(EngineDllBaseAddress + 0x111E18DC) != 0;
         }
 
         public Titan GetTitan()
         {
             _ensureInit();
-            return TitanMethods.GetTitan(_sharp!.Memory.Read(_engineDllBaseAddress + 0x7A7429, 1)[0]);
+            return TitanMethods.GetTitan(_sharp!.Memory.Read(EngineDllBaseAddress + 0x7A7429, 1)[0]);
         }
 
         public int GetPlayerVelocity()

--- a/titanfall2-rp/Titanfall2API.cs
+++ b/titanfall2-rp/Titanfall2API.cs
@@ -77,6 +77,12 @@ namespace titanfall2_rp
             return _sharp!.Memory.Read<int>(_engineDllBaseAddress + 0x111E18DC) != 0;
         }
 
+        public Titan GetTitan()
+        {
+            _ensureInit();
+            return TitanMethods.GetTitan(_sharp!.Memory.Read(_engineDllBaseAddress + 0x7A7429,1)[0]);
+        }
+
         public int GetPlayerVelocity()
         {
             _ensureInit();

--- a/titanfall2-rp/Titanfall2API.cs
+++ b/titanfall2-rp/Titanfall2API.cs
@@ -80,7 +80,7 @@ namespace titanfall2_rp
         public Titan GetTitan()
         {
             _ensureInit();
-            return TitanMethods.GetTitan(_sharp!.Memory.Read(_engineDllBaseAddress + 0x7A7429,1)[0]);
+            return TitanMethods.GetTitan(_sharp!.Memory.Read(_engineDllBaseAddress + 0x7A7429, 1)[0]);
         }
 
         public int GetPlayerVelocity()

--- a/titanfall2-rp/enums/Titan.cs
+++ b/titanfall2-rp/enums/Titan.cs
@@ -26,7 +26,7 @@
 
         public static string GetAssetName(this Titan titan)
         {
-            return titan.ToString();
+            return titan.ToString().ToLower();
         }
     }
 }

--- a/titanfall2-rp/enums/Titan.cs
+++ b/titanfall2-rp/enums/Titan.cs
@@ -1,0 +1,32 @@
+﻿namespace titanfall2_rp.enums
+{
+    public enum Titan
+    {
+        Ion,
+        Scorch,
+        Northstar,
+        // ReSharper disable once IdentifierTypo
+        Ronin,
+        Tone,
+        Legion,
+        Monarch,
+    }
+
+    internal static class TitanMethods
+    {
+        public static Titan GetTitan(int titanValue)
+        {
+            return (Titan)titanValue;
+        }
+
+        public static string ToFriendlyString(this Titan titan)
+        {
+            return titan.ToString();
+        }
+
+        public static string GetAssetName(this Titan titan)
+        {
+            return titan.ToString();
+        }
+    }
+}


### PR DESCRIPTION
Closes #18. Shows the titan you're using when you're in one. (this is a little inconsistent and will sometimes think you're in a titan between rounds of titan brawl).

Sadly, the Icon has its transparency missing and instead is black. This feature works but the icons don't look all that great. Help is wanted with this.