### PR TITLE
Slightly correct the starting time

### DIFF
--- a/titanfall2-rp/ProcessNetApi.cs
+++ b/titanfall2-rp/ProcessNetApi.cs
@@ -34,7 +34,7 @@ namespace titanfall2_rp
             Log.Debug("Found '" + ProcessName + "'" + "!");
             var proc = processSearch[0];
             _sharp = new ProcessSharp(proc, MemoryType.Remote);
-            StartTimestamp = DateTimeOffset.Now.UtcDateTime;
+            StartTimestamp = _sharp.Native.StartTime.ToUniversalTime();
             return true;
         }
 


### PR DESCRIPTION
The previous start time was set as soon as the program discovered a running instance of Titanfall 2. However, this could lead to incorrect play times. Instead, the true start time is fetched from the process itself.

Closes #67 but might reopen something akin to #74 if I messed this up.