### PR TITLE
Adjust auto-update download URL

### DIFF
--- a/assets/auto-update-template.xml
+++ b/assets/auto-update-template.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <item>
     <version>${VERSION}</version>
-    <url>https://github.com/IncPlusPlus/titanfall2-rp/releases/latest/download/titanfall2-rp.zip</url>
+    <url>https://github.com/IncPlusPlus/titanfall2-rp/releases/download/v${VERSION}/titanfall2-rp.zip</url>
     <changelog>https://github.com/IncPlusPlus/titanfall2-rp/releases/tag/v${VERSION}#start-of-content</changelog>
     <mandatory>true</mandatory>
 </item>


### PR DESCRIPTION
The URL in the update XML points to the latest version. This would ordinarily be desired behavior but I want it to point at the specific version that the XML file specifies.