### PR TITLE
Remove annoying update alert dialogs

### DIFF
--- a/titanfall2-rp/Program.cs
+++ b/titanfall2-rp/Program.cs
@@ -49,7 +49,6 @@ namespace titanfall2_rp
             {
                 Log.Info("Checking for updates...");
                 AutoUpdater.Synchronous = true;
-                AutoUpdater.ReportErrors = true;
                 AutoUpdater.ApplicationExitEvent += AutoUpdater_ApplicationExitEvent;
                 AutoUpdater.Start("https://github.com/IncPlusPlus/titanfall2-rp/releases/latest/download/updater-helper-file.xml");
             }


### PR DESCRIPTION
Apparently, a setting to "report errors" also mean that a dialog would appear if there were no updates. That's stupid. I've disabled it.