### PR TITLE
Fix the namespace getting messed up

### DIFF
--- a/titanfall2-rp/titanfall2-rp.csproj
+++ b/titanfall2-rp/titanfall2-rp.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <AssemblyName>titanfall2-rp-lib</AssemblyName>
+        <RootNamespace>titanfall2_rp</RootNamespace>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 


### PR DESCRIPTION
This kept making the Resources.Designer.cs file in the titanfall2-rp project change its namespace from titanfall2_rp to titanfall2-rp and breaking itself. Bye bye, pesky bug!