### PR TITLE
Fix Windows version crashing at startup

### DIFF
--- a/Windows/App.xaml.cs
+++ b/Windows/App.xaml.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Forms;
 using Common;
+using log4net;
 using titanfall2_rp.updater;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.WPF;
@@ -16,15 +18,32 @@ namespace titanfall2_rp.Windows
     /// </summary>
     public partial class App
     {
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod()!.DeclaringType);
         private NotifyIcon? _notifyIcon;
         private RichPresenceManager? _program;
         private bool _isExit;
 
         protected override void OnStartup(StartupEventArgs e)
         {
-            Forms.Init();
+            try
+            {
+                Forms.Init();
+            }
+            catch (Exception exception)
+            {
+                Log.Fatal("Failed at Forms.Init()", exception);
+                throw;
+            }
 
-            base.OnStartup(e);
+            try
+            {
+                base.OnStartup(e);
+            }
+            catch (Exception exception)
+            {
+                Log.Fatal("Failed at base.OnStartup(e)", exception);
+                throw;
+            }
 
             _notifyIcon = new NotifyIcon();
             _notifyIcon.MouseDoubleClick += NotifyIconOnDoubleClick;
@@ -33,8 +52,16 @@ namespace titanfall2_rp.Windows
             _notifyIcon.Visible = true;
             _notifyIcon.Text = "Titanfall 2 Discord Rich Presence";
 
-            CreateContextMenu();
-
+            try
+            {
+                CreateContextMenu();
+            }
+            catch (Exception exception)
+            {
+                Log.Fatal("Failed at CreateContextMenu()", exception);
+                throw;
+            }
+            
             _program = new RichPresenceManager();
             _program.Begin();
         }

--- a/Windows/App.xaml.cs
+++ b/Windows/App.xaml.cs
@@ -25,6 +25,9 @@ namespace titanfall2_rp.Windows
 
         protected override void OnStartup(StartupEventArgs e)
         {
+            _program = new RichPresenceManager();
+            _program.Begin();
+
             try
             {
                 Forms.Init();
@@ -61,9 +64,6 @@ namespace titanfall2_rp.Windows
                 Log.Fatal("Failed at CreateContextMenu()", exception);
                 throw;
             }
-            
-            _program = new RichPresenceManager();
-            _program.Begin();
         }
 
         private void NotifyIconOnDoubleClick(object? sender, MouseEventArgs e)

--- a/Windows/Windows.csproj
+++ b/Windows/Windows.csproj
@@ -15,6 +15,7 @@
         <!--https://docs.microsoft.com/en-us/answers/questions/296816/self-contained-single-file-does-not-produce-a-sing.html-->
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <Nullable>enable</Nullable>
+        <UseNETCoreGenerator>true</UseNETCoreGenerator>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -59,6 +60,12 @@
     <ItemGroup>
       <ProjectReference Include="..\Common\Common.csproj" />
       <ProjectReference Include="..\titanfall2-rp\titanfall2-rp.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!--https://docs.microsoft.com/en-us/dotnet/core/deploying/trim-self-contained#prevent-assemblies-from-being-trimmed-->
+        <!--Without this, illink gets rid of it and causes WPF to crash as soon as Forms.Init() gets called-->
+        <TrimmerRootAssembly Include="System.Runtime" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Turns out, illink was trimming `System.Runtime` out of the build when running `dotnet publish`.