### PR TITLE
Allow users to reload the config file

### DIFF
--- a/Common/Config.cs
+++ b/Common/Config.cs
@@ -79,6 +79,11 @@ namespace Common
             }
         }
 
+        public static void ReloadFromFile()
+        {
+            Init();
+        }
+
         private static void ConfigureDefaults()
         {
             _config = new Configuration

--- a/Windows/App.xaml.cs
+++ b/Windows/App.xaml.cs
@@ -106,6 +106,10 @@ namespace titanfall2_rp.Windows
             {
                 if (!ProcessUtil.ShowFile(Config.ConfigFileName)) NotifyUserOfError();
             };
+            _notifyIcon.ContextMenuStrip.Items.Add("Reload the settings file").Click += (_, _) =>
+            {
+                Config.ReloadFromFile();
+            };
             _notifyIcon.ContextMenuStrip.Items.Add("Check for Updates").Click +=
                 (_, _) => UpdateHelper.Updater.Update();
             _notifyIcon.ContextMenuStrip.Items.Add("Exit").Click += (s, e) => ExitApplication();


### PR DESCRIPTION
This adds a menu option that, when clicked, will overwrite the in-memory config with whatever the user has in their config file. This is useful in cases where the user has made a change to their config file and wants the program to use that new value without having to restart the whole program.

Fixes #123 