### PR TITLE
Prevent the EXE from being renamed (good find, Iris!)

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -22,6 +22,6 @@ namespace Common
             System.Diagnostics.Debugger.IsAttached ||
             // This is the default version for this project when there is no RELEASE_VERSION env var
             Assembly.GetEntryAssembly()!.GetName().Version!.Equals(new Version(0,
-                0, 1,0));
+                0, 1, 0));
     }
 }

--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Reflection;
 
 namespace Common
 {
@@ -9,5 +10,18 @@ namespace Common
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "titanfall2-rp"
         );
+
+        /// <summary>
+        /// True when this is being run off of a local build (i.e. with `dotnet build/release` without a version set)
+        /// or from an IDE. This is a multi-purpose variable and can be used to avoid checking end-user stuff that
+        /// would never be true in an IDE like whether the current version is up-to-date or whether the currently running
+        /// assembly is named "titanfall2-rp.exe" (it appears as "titanfall2-rp.dll" when running a local build). 
+        /// </summary>
+        public static bool IsLocalBuild =>
+            // Obviously if a debugger is attached, this isn't being run by an end-user
+            System.Diagnostics.Debugger.IsAttached ||
+            // This is the default version for this project when there is no RELEASE_VERSION env var
+            Assembly.GetEntryAssembly()!.GetName().Version!.Equals(new Version(0,
+                0, 1,0));
     }
 }

--- a/Windows/App.xaml.cs
+++ b/Windows/App.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Forms;
 using Common;
 using log4net;
+using titanfall2_rp.SegmentManager;
 using titanfall2_rp.updater;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.WPF;
@@ -22,46 +23,40 @@ namespace titanfall2_rp.Windows
         private NotifyIcon? _notifyIcon;
         private RichPresenceManager? _program;
         private bool _isExit;
+        private bool _formsInitCalled;
 
         protected override void OnStartup(StartupEventArgs e)
         {
-            _program = new RichPresenceManager();
-            _program.Begin();
-
             try
             {
+                _program = new RichPresenceManager();
+                _program.Begin();
                 Forms.Init();
-            }
-            catch (Exception exception)
-            {
-                Log.Fatal("Failed at Forms.Init()", exception);
-                throw;
-            }
-
-            try
-            {
+                _formsInitCalled = true;
                 base.OnStartup(e);
-            }
-            catch (Exception exception)
-            {
-                Log.Fatal("Failed at base.OnStartup(e)", exception);
-                throw;
-            }
 
-            _notifyIcon = new NotifyIcon();
-            _notifyIcon.MouseDoubleClick += NotifyIconOnDoubleClick;
-            _notifyIcon.MouseMove += NotifyIconOnMouseMove;
-            _notifyIcon.Icon = titanfall2_rp.Windows.Properties.Resources.TrayIcon;
-            _notifyIcon.Visible = true;
-            _notifyIcon.Text = "Titanfall 2 Discord Rich Presence";
+                _notifyIcon = new NotifyIcon();
+                _notifyIcon.MouseDoubleClick += NotifyIconOnDoubleClick;
+                _notifyIcon.MouseMove += NotifyIconOnMouseMove;
+                _notifyIcon.Icon = titanfall2_rp.Windows.Properties.Resources.TrayIcon;
+                _notifyIcon.Visible = true;
+                _notifyIcon.Text = "Titanfall 2 Discord Rich Presence";
 
-            try
-            {
                 CreateContextMenu();
             }
             catch (Exception exception)
             {
-                Log.Fatal("Failed at CreateContextMenu()", exception);
+                Log.Fatal("Failed to start. Encountered an exception in OnStartup", exception);
+                SegmentManager.SegmentManager.TrackEvent(TrackableEvent.GameplayInfoFailure,exception);
+
+                if (_formsInitCalled)
+                {
+                    MessageBox.Show(
+                        $"An fatal exception occurred! See below for details (this info will also be logged). " +
+                        $"You can also press CTRL + C to copy this error to the clipboard.\n\n\n" +
+                        $"Message: {exception.Message}\n\n\nFull exception:\n{exception}", "Titanfall 2 Discord Rich Presence",
+                        MessageBoxButton.OK, MessageBoxImage.Error);
+                }
                 throw;
             }
         }

--- a/Windows/App.xaml.cs
+++ b/Windows/App.xaml.cs
@@ -47,7 +47,7 @@ namespace titanfall2_rp.Windows
             catch (Exception exception)
             {
                 Log.Fatal("Failed to start. Encountered an exception in OnStartup", exception);
-                SegmentManager.SegmentManager.TrackEvent(TrackableEvent.GameplayInfoFailure,exception);
+                SegmentManager.SegmentManager.TrackEvent(TrackableEvent.GameplayInfoFailure, exception);
 
                 if (_formsInitCalled)
                 {

--- a/titanfall2-rp/RichPresenceManager.cs
+++ b/titanfall2-rp/RichPresenceManager.cs
@@ -111,6 +111,7 @@ namespace titanfall2_rp
         /// <footer><a href="https://github.com/ravibpatel/AutoUpdater.NET/issues/244">The open issue</a></footer>
         private static void EnsureNotRenamed()
         {
+            if (Constants.IsLocalBuild) return;
             if (Assembly.GetEntryAssembly()!.Location != GetDefaultExecutableName())
             {
                 throw new ApplicationException(

--- a/titanfall2-rp/RichPresenceManager.cs
+++ b/titanfall2-rp/RichPresenceManager.cs
@@ -112,10 +112,10 @@ namespace titanfall2_rp
         private static void EnsureNotRenamed()
         {
             if (Constants.IsLocalBuild) return;
-            if (Assembly.GetEntryAssembly()!.Location != GetDefaultExecutableName())
+            if (System.Diagnostics.Process.GetCurrentProcess().MainModule?.ModuleName != GetDefaultExecutableName())
             {
                 throw new ApplicationException(
-                    $"This application must not be renamed. It should be named '{GetDefaultExecutableName()}' but was named '{Assembly.GetEntryAssembly()!.Location}'.");
+                    $"This application must not be renamed. It should be named '{GetDefaultExecutableName()}' but was named '{System.Diagnostics.Process.GetCurrentProcess().MainModule?.ModuleName}'.");
             }
         }
 


### PR DESCRIPTION
This is a temporary measure to stop the program from running and notify the user if they've changed the name of the exe file to anything other than the default name.

This is because of ravibpatel/AutoUpdater.NET#244