### PR TITLE
Re-add map titles

### DIFF
--- a/titanfall2-rp/GameDetailsProvider.cs
+++ b/titanfall2-rp/GameDetailsProvider.cs
@@ -12,7 +12,7 @@ namespace titanfall2_rp
             string gameDetails = tf2Api.GetGameMode().ToFriendlyString();
             string gameState = $"Score: {mpStats.GetMyTeamScore()} - {mpStats.GetEnemyTeamScore()}";
             var timestamps = new Timestamps(gameOpenTimestamp);
-            var map = Map.FromName(tf2Api.GetMultiplayerMapName()); 
+            var map = Map.FromName(tf2Api.GetMultiplayerMapName());
             var playerInTitan = tf2Api.IsPlayerInTitan();
             var assets = new Assets
             {

--- a/titanfall2-rp/GameDetailsProvider.cs
+++ b/titanfall2-rp/GameDetailsProvider.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using DiscordRPC;
 using titanfall2_rp.enums;
 
@@ -9,15 +6,6 @@ namespace titanfall2_rp
 {
     public static class GameDetailsProvider
     {
-        /// <summary>
-        /// This string was created by listing all of the files in `assets/map previews/square` with `ls -1`
-        /// and then manually chopping off the file extensions. Then I put it in a verbatim string and used the context
-        /// actions menu to turn it into a regular string. In verbatim string form, it had both carriage returns
-        /// and newlines. In the regular string form, it's just newlines.
-        /// KEEP THIS CONSISTENT WITH THE ASSET NAMES!!!
-        /// </summary>
-        [SuppressMessage("ReSharper", "StringLiteralTypo")] private static readonly string[] AllMapAssetNames = "mp_angel_city\nmp_black_water_canal\nmp_coliseum\nmp_coliseum_column\nmp_colony02\nmp_complex3\nmp_crashsite3\nmp_drydock\nmp_eden\nmp_forwardbase_kodai\nmp_glitch\nmp_grave\nmp_homestead\nmp_lf_deck\nmp_lf_meadow\nmp_lf_stacks\nmp_lf_township\nmp_lf_traffic\nmp_lf_uma\nmp_relic02\nmp_rise\nmp_thaw\nmp_wargames\nsp_beacon_1\nsp_beacon_2\nsp_beacon_3\nsp_beacon_4\nsp_beacon_5\nsp_beacon_spoke0_1\nsp_beacon_spoke0_2\nsp_beacon_spoke0_3\nsp_boomtown_1\nsp_boomtown_2\nsp_boomtown_3\nsp_boomtown_end_1\nsp_boomtown_end_2\nsp_boomtown_end_3\nsp_boomtown_end_4\nsp_boomtown_start_1\nsp_boomtown_start_2\nsp_crashsite_1\nsp_crashsite_2\nsp_hub_timeshift_1\nsp_hub_timeshift_2\nsp_hub_timeshift_3\nsp_s2s_1\nsp_s2s_2\nsp_s2s_3\nsp_s2s_4\nsp_s2s_5\nsp_sewers1_1\nsp_sewers1_2\nsp_sewers1_3\nsp_sewers1_4\nsp_sewers1_5\nsp_sewers1_6\nsp_sewers1_7\nsp_sewers1_8\nsp_skyway_v1_1\nsp_skyway_v1_2\nsp_skyway_v1_3\nsp_skyway_v1_4\nsp_skyway_v1_5\nsp_skyway_v1_6\nsp_tday_1\nsp_tday_2\nsp_tday_3\nsp_tday_4\nsp_tday_5\nsp_timeshift_spoke02_1\nsp_timeshift_spoke02_2\nsp_timeshift_spoke02_3\nsp_timeshift_spoke02_4\nsp_training_1\nsp_training_2".Split("\n");
-
         public static (string, string, Timestamps?, Assets? assets) GetMultiplayerDetails(Titanfall2Api tf2Api, DateTime gameOpenTimestamp)
         {
             var mpStats = tf2Api.GetMultiPlayerGameStats();
@@ -28,7 +16,7 @@ namespace titanfall2_rp
             var assets = new Assets
             {
                 LargeImageKey = tf2Api.GetMultiplayerMapName(),
-                LargeImageText = tf2Api.GetMultiplayerMapName(),
+                LargeImageText = Map.FromName(tf2Api.GetMultiplayerMapName()).InEnglish(),
                 SmallImageKey = playerInTitan ? tf2Api.GetTitan().GetAssetName() : mpStats.GetCurrentFaction().GetAssetName(),
                 SmallImageText = playerInTitan ? tf2Api.GetTitan().ToFriendlyString() : mpStats.GetCurrentFaction().ToFriendlyString(),
             };
@@ -53,22 +41,7 @@ namespace titanfall2_rp
         /// <returns>one of the asset names of of the applicable map</returns>
         private static string GetRandomImageNameForCurrentMap(Titanfall2Api tf2Api)
         {
-            string currentMapName = tf2Api.GetSinglePlayerMapName();
-            var candidates = AllMapAssetNames.Where(assetName => assetName.StartsWith(currentMapName));
-            return candidates.RandomElement();
-        }
-
-        // https://stackoverflow.com/a/7259419/1687436
-        private static T RandomElement<T>(this IEnumerable<T> enumerable)
-        {
-            return enumerable.RandomElementUsing<T>(new Random());
-        }
-
-        [SuppressMessage("ReSharper", "PossibleMultipleEnumeration")]
-        private static T RandomElementUsing<T>(this IEnumerable<T> enumerable, Random rand)
-        {
-            var index = rand.Next(0, enumerable.Count());
-            return enumerable.ElementAt(index);
+            return Map.FromName(tf2Api.GetSinglePlayerMapName()).GetRandomPreview();
         }
     }
 }

--- a/titanfall2-rp/GameDetailsProvider.cs
+++ b/titanfall2-rp/GameDetailsProvider.cs
@@ -12,11 +12,12 @@ namespace titanfall2_rp
             string gameDetails = tf2Api.GetGameMode().ToFriendlyString();
             string gameState = $"Score: {mpStats.GetMyTeamScore()} - {mpStats.GetEnemyTeamScore()}";
             var timestamps = new Timestamps(gameOpenTimestamp);
+            var map = Map.FromName(tf2Api.GetMultiplayerMapName()); 
             var playerInTitan = tf2Api.IsPlayerInTitan();
             var assets = new Assets
             {
-                LargeImageKey = tf2Api.GetMultiplayerMapName(),
-                LargeImageText = Map.FromName(tf2Api.GetMultiplayerMapName()).InEnglish(),
+                LargeImageKey = map.ToString(),
+                LargeImageText = map.InEnglish(),
                 SmallImageKey = playerInTitan ? tf2Api.GetTitan().GetAssetName() : mpStats.GetCurrentFaction().GetAssetName(),
                 SmallImageText = playerInTitan ? tf2Api.GetTitan().ToFriendlyString() : mpStats.GetCurrentFaction().ToFriendlyString(),
             };

--- a/titanfall2-rp/PresenceUpdateThread.cs
+++ b/titanfall2-rp/PresenceUpdateThread.cs
@@ -131,7 +131,7 @@ namespace titanfall2_rp
             else if (tf2Api.GetGameMode() == GameMode.solo)
             {
                 gameDetails = $"{tf2Api.GetGameModeName()} ({tf2Api.GetSinglePlayerDifficulty()})";
-                gameState = tf2Api.GetSinglePlayerMapName();
+                gameState = Map.FromName(tf2Api.GetSinglePlayerMapName()).InEnglish();
                 timestamps = new Timestamps(ProcessNetApi.StartTimestamp);
                 assets = GameDetailsProvider.GetSinglePlayerAssets(tf2Api);
             }

--- a/titanfall2-rp/enums/Map.cs
+++ b/titanfall2-rp/enums/Map.cs
@@ -47,7 +47,7 @@ namespace titanfall2_rp.enums
         public static readonly Map sp_beacon_spoke0 = new(nameof(sp_beacon_spoke0), "sp_beacon_spoke0", 1);
         public static readonly Map sp_boomtown = new(nameof(sp_boomtown), "sp_boomtown", 1);
         public static readonly Map sp_boomtown_end = new(nameof(sp_boomtown_end), "sp_boomtown_end", 1);
-        public static readonly Map sp_boomtown_start = new(nameof(sp_boomtown_start), "sp_boomtown_start", 1);
+        public static readonly Map sp_boomtown_start = new(nameof(sp_boomtown_start), "Into the Abyss", 1);
         public static readonly Map sp_crashsite = new(nameof(sp_crashsite), "sp_crashsite", 1);
         public static readonly Map sp_hub_timeshift = new(nameof(sp_hub_timeshift), "sp_hub_timeshift", 1);
         public static readonly Map sp_s2s = new(nameof(sp_s2s), "sp_s2s", 1);

--- a/titanfall2-rp/enums/Map.cs
+++ b/titanfall2-rp/enums/Map.cs
@@ -51,7 +51,7 @@ namespace titanfall2_rp.enums
         public static readonly Map sp_crashsite = new(nameof(sp_crashsite), "sp_crashsite", 1);
         public static readonly Map sp_hub_timeshift = new(nameof(sp_hub_timeshift), "sp_hub_timeshift", 1);
         public static readonly Map sp_s2s = new(nameof(sp_s2s), "sp_s2s", 1);
-        public static readonly Map sp_sewers1 = new(nameof(sp_sewers1), "sp_sewers1", 1);
+        public static readonly Map sp_sewers1 = new(nameof(sp_sewers1), "Blood and Rust", 1);
         public static readonly Map sp_skyway_v1 = new(nameof(sp_skyway_v1), "sp_skyway_v1", 1);
         public static readonly Map sp_tday = new(nameof(sp_tday), "sp_tday", 1);
         public static readonly Map sp_timeshift_spoke02 = new(nameof(sp_timeshift_spoke02), "sp_timeshift_spoke02", 1);

--- a/titanfall2-rp/enums/Map.cs
+++ b/titanfall2-rp/enums/Map.cs
@@ -42,20 +42,19 @@ namespace titanfall2_rp.enums
         public static readonly Map mp_rise = new(nameof(mp_rise), "Rise", 1);
         public static readonly Map mp_thaw = new(nameof(mp_thaw), "Thaw", 1);
         public static readonly Map mp_wargames = new(nameof(mp_wargames), "War Games", 1);
-        // TODO: All of these SP maps need their campaign names! Oh boy! Time to replay the campaign!
-        public static readonly Map sp_beacon = new(nameof(sp_beacon), "sp_beacon", 1);
-        public static readonly Map sp_beacon_spoke0 = new(nameof(sp_beacon_spoke0), "sp_beacon_spoke0", 1);
-        public static readonly Map sp_boomtown = new(nameof(sp_boomtown), "sp_boomtown", 1);
-        public static readonly Map sp_boomtown_end = new(nameof(sp_boomtown_end), "sp_boomtown_end", 1);
-        public static readonly Map sp_boomtown_start = new(nameof(sp_boomtown_start), "Into the Abyss", 1);
-        public static readonly Map sp_crashsite = new(nameof(sp_crashsite), "sp_crashsite", 1);
-        public static readonly Map sp_hub_timeshift = new(nameof(sp_hub_timeshift), "sp_hub_timeshift", 1);
-        public static readonly Map sp_s2s = new(nameof(sp_s2s), "sp_s2s", 1);
+        public static readonly Map sp_beacon = new(nameof(sp_beacon), "The Beacon (Chapter 1 or 3)", 1);
+        public static readonly Map sp_beacon_spoke0 = new(nameof(sp_beacon_spoke0), "The Beacon (Chapter 2)", 1);
+        public static readonly Map sp_boomtown = new(nameof(sp_boomtown), "Into the Abyss (Chapter 2)", 1);
+        public static readonly Map sp_boomtown_end = new(nameof(sp_boomtown_end), "Into the Abyss (Chapter 3)", 1);
+        public static readonly Map sp_boomtown_start = new(nameof(sp_boomtown_start), "Into the Abyss (Chapter 1)", 1);
+        public static readonly Map sp_crashsite = new(nameof(sp_crashsite), "BT-7274", 1);
+        public static readonly Map sp_hub_timeshift = new(nameof(sp_hub_timeshift), "Effect and Cause (Chapter 1 or 3)", 1);
+        public static readonly Map sp_s2s = new(nameof(sp_s2s), "The Ark", 1);
         public static readonly Map sp_sewers1 = new(nameof(sp_sewers1), "Blood and Rust", 1);
-        public static readonly Map sp_skyway_v1 = new(nameof(sp_skyway_v1), "sp_skyway_v1", 1);
-        public static readonly Map sp_tday = new(nameof(sp_tday), "sp_tday", 1);
-        public static readonly Map sp_timeshift_spoke02 = new(nameof(sp_timeshift_spoke02), "sp_timeshift_spoke02", 1);
-        public static readonly Map sp_training = new(nameof(sp_training), "sp_training", 1);
+        public static readonly Map sp_skyway_v1 = new(nameof(sp_skyway_v1), "The Fold Weapon", 1);
+        public static readonly Map sp_tday = new(nameof(sp_tday), "Trial by Fire", 1);
+        public static readonly Map sp_timeshift_spoke02 = new(nameof(sp_timeshift_spoke02), "Effect and Cause (Chapter 2)", 1);
+        public static readonly Map sp_training = new(nameof(sp_training), "The Pilot's Gauntlet", 1);
         // ReSharper restore IdentifierTypo
         // ReSharper restore InconsistentNaming
 

--- a/titanfall2-rp/enums/Map.cs
+++ b/titanfall2-rp/enums/Map.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Ardalis.SmartEnum;
+
+namespace titanfall2_rp.enums
+{
+    /// <summary>
+    /// A quick and dirty way to keep a list of maps that isn't just strings so they can be strongly typed for future
+    /// use.
+    /// </summary>
+    public sealed class Map : SmartEnum<Map, string>
+    {
+        public int MapPreviewVariants { get; }
+
+        public Map(string name, string mapNameInEnglish, int mapPreviewVariants) : base(name, mapNameInEnglish)
+        {
+            MapPreviewVariants = mapPreviewVariants;
+        }
+
+        // ReSharper disable InconsistentNaming
+        // ReSharper disable IdentifierTypo
+        public static readonly Map mp_angel_city = new(nameof(mp_angel_city), "Angel City", 1);
+        public static readonly Map mp_black_water_canal = new(nameof(mp_black_water_canal), "Black Water Canal", 1);
+        public static readonly Map mp_coliseum = new(nameof(mp_coliseum), "The Coliseum", 1);
+        public static readonly Map mp_coliseum_column = new(nameof(mp_coliseum_column), "Pillars", 1);
+        public static readonly Map mp_colony02 = new(nameof(mp_colony02), "Colony", 1);
+        public static readonly Map mp_complex3 = new(nameof(mp_complex3), "Complex", 1);
+        public static readonly Map mp_crashsite3 = new(nameof(mp_crashsite3), "Crash Site", 1);
+        public static readonly Map mp_drydock = new(nameof(mp_drydock), "Drydock", 1);
+        public static readonly Map mp_eden = new(nameof(mp_eden), "Eden", 1);
+        public static readonly Map mp_forwardbase_kodai = new(nameof(mp_forwardbase_kodai), "Forwardbase Kodai", 1);
+        public static readonly Map mp_glitch = new(nameof(mp_glitch), "Glitch", 1);
+        public static readonly Map mp_grave = new(nameof(mp_grave), "Grave", 1);
+        public static readonly Map mp_homestead = new(nameof(mp_homestead), "Homestead", 1);
+        public static readonly Map mp_lf_deck = new(nameof(mp_lf_deck), "Deck", 1);
+        public static readonly Map mp_lf_meadow = new(nameof(mp_lf_meadow), "Meadow", 1);
+        public static readonly Map mp_lf_stacks = new(nameof(mp_lf_stacks), "Stacks", 1);
+        public static readonly Map mp_lf_township = new(nameof(mp_lf_township), "Township", 1);
+        public static readonly Map mp_lf_traffic = new(nameof(mp_lf_traffic), "Traffic", 1);
+        public static readonly Map mp_lf_uma = new(nameof(mp_lf_uma), "UMA", 1);
+        public static readonly Map mp_lobby = new(nameof(mp_lobby), "mp_lobby", 1);
+        public static readonly Map mp_relic02 = new(nameof(mp_relic02), "Relic", 1);
+        public static readonly Map mp_rise = new(nameof(mp_rise), "Rise", 1);
+        public static readonly Map mp_thaw = new(nameof(mp_thaw), "Thaw", 1);
+        public static readonly Map mp_wargames = new(nameof(mp_wargames), "War Games", 1);
+        // TODO: All of these SP maps need their campaign names! Oh boy! Time to replay the campaign!
+        public static readonly Map sp_beacon = new(nameof(sp_beacon), "sp_beacon", 1);
+        public static readonly Map sp_beacon_spoke0 = new(nameof(sp_beacon_spoke0), "sp_beacon_spoke0", 1);
+        public static readonly Map sp_boomtown = new(nameof(sp_boomtown), "sp_boomtown", 1);
+        public static readonly Map sp_boomtown_end = new(nameof(sp_boomtown_end), "sp_boomtown_end", 1);
+        public static readonly Map sp_boomtown_start = new(nameof(sp_boomtown_start), "sp_boomtown_start", 1);
+        public static readonly Map sp_crashsite = new(nameof(sp_crashsite), "sp_crashsite", 1);
+        public static readonly Map sp_hub_timeshift = new(nameof(sp_hub_timeshift), "sp_hub_timeshift", 1);
+        public static readonly Map sp_s2s = new(nameof(sp_s2s), "sp_s2s", 1);
+        public static readonly Map sp_sewers1 = new(nameof(sp_sewers1), "sp_sewers1", 1);
+        public static readonly Map sp_skyway_v1 = new(nameof(sp_skyway_v1), "sp_skyway_v1", 1);
+        public static readonly Map sp_tday = new(nameof(sp_tday), "sp_tday", 1);
+        public static readonly Map sp_timeshift_spoke02 = new(nameof(sp_timeshift_spoke02), "sp_timeshift_spoke02", 1);
+        public static readonly Map sp_training = new(nameof(sp_training), "sp_training", 1);
+        // ReSharper restore IdentifierTypo
+        // ReSharper restore InconsistentNaming
+
+        /// <summary>
+        /// If there are multiple preview images for this map (as is the case with the single-player maps, this method
+        /// will randomly return one of the asset names for this specific map. See the map previews in the assets
+        /// folder for more context.
+        /// </summary>
+        /// <returns>a random applicable map preview name for the given map</returns>
+        public string GetRandomPreview()
+        {
+            return MapPreviewVariants.Equals(1) ? Name : $"{Name}_{new Random().Next(1, MapPreviewVariants)}";
+        }
+
+        public string InEnglish()
+        {
+            return Value;
+        }
+    }
+}

--- a/titanfall2-rp/titanfall2-rp.csproj
+++ b/titanfall2-rp/titanfall2-rp.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="Analytics" Version="3.8.0" />
+      <PackageReference Include="Ardalis.SmartEnum" Version="2.0.1" />
       <PackageReference Include="Autoupdater.NET.Official" Version="1.7.0" />
       <PackageReference Include="DiscordRichPresence" Version="1.0.175" />
       <PackageReference Include="log4net" Version="2.0.12" />


### PR DESCRIPTION
The introduction of #148 made the map name look gross and_riddled_with_underscores (out of necessity). This PR brings the proper names back and closes #147.