### PR TITLE
Support Northstar 1.4.0

### DIFF
--- a/titanfall2-rp/ProcessNetApi.cs
+++ b/titanfall2-rp/ProcessNetApi.cs
@@ -10,7 +10,7 @@ namespace titanfall2_rp
     public static class ProcessNetApi
     {
         private const string ProcessName = "Titanfall2";
-        private const string NorthstarProcessName = "Titanfall2-unpacked";
+        private const string NorthstarProcessName = "NorthstarLauncher";
         private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod()!.DeclaringType);
 
         private static ProcessSharp? _sharp;


### PR DESCRIPTION
Due to R2Northstar/NorthstarLauncher#19, there's no longer a process with the name `Titanfall2-unpacked`. It is now `NorthstarLauncher`. This will ensure that the right process is found.