### PR TITLE
Add a fallback for unknown gamemodes

### DIFF
--- a/titanfall2-rp/GameDetailsProvider.cs
+++ b/titanfall2-rp/GameDetailsProvider.cs
@@ -12,7 +12,7 @@ namespace titanfall2_rp
             var mpStats = tf2Api.GetMultiPlayerGameStats();
             var gameMode = tf2Api.GetGameMode();
             var gameDetails = gameMode == GameMode.UNKNOWN_GAME_MODE
-                ? $"Gamemode: {tf2Api.GetGameModeCodeName()}"
+                ? $"Game mode: {tf2Api.GetGameModeCodeName()}"
                 : gameMode.ToFriendlyString();
             var gameState = mpStats.GetGameState();
             var timestamps = new Timestamps(gameOpenTimestamp);

--- a/titanfall2-rp/GameDetailsProvider.cs
+++ b/titanfall2-rp/GameDetailsProvider.cs
@@ -10,7 +10,10 @@ namespace titanfall2_rp
             DateTime gameOpenTimestamp)
         {
             var mpStats = tf2Api.GetMultiPlayerGameStats();
-            var gameDetails = tf2Api.GetGameMode().ToFriendlyString();
+            var gameMode = tf2Api.GetGameMode();
+            var gameDetails = gameMode == GameMode.UNKNOWN_GAME_MODE
+                ? $"Gamemode: {tf2Api.GetGameModeCodeName()}"
+                : gameMode.ToFriendlyString();
             var gameState = mpStats.GetGameState();
             var timestamps = new Timestamps(gameOpenTimestamp);
             var map = Map.FromName(tf2Api.GetMultiplayerMapName());

--- a/titanfall2-rp/MpGameStats/UnknownGameMode.cs
+++ b/titanfall2-rp/MpGameStats/UnknownGameMode.cs
@@ -1,0 +1,16 @@
+﻿using Process.NET;
+
+namespace titanfall2_rp.MpGameStats
+{
+    public class UnknownGameMode : MpStats
+    {
+        public UnknownGameMode(Titanfall2Api tf2Api, ProcessSharp processSharp) : base(tf2Api, processSharp)
+        {
+        }
+
+        public override string GetGameState()
+        {
+            return "In a match";
+        }
+    }
+}

--- a/titanfall2-rp/MpStats.cs
+++ b/titanfall2-rp/MpStats.cs
@@ -142,7 +142,7 @@ namespace titanfall2_rp
         /// more appropriate string.
         /// </summary>
         /// <returns>a string representing the current state of the match</returns>
-        public virtual String GetGameState()
+        public virtual string GetGameState()
         {
             return $"Score: {GetMyTeamScore()} - {GetEnemyTeamScore()}";
         }
@@ -262,15 +262,15 @@ namespace titanfall2_rp
                 GameMode.turbo_ttdm => new TitanBrawl(titanfall2Api, sharp),
                 GameMode.alts => new LastTitanStanding(titanfall2Api, sharp),
                 GameMode.turbo_lts => new LastTitanStanding(titanfall2Api, sharp),
-                _ => ReportGameModeFailure(gameMode)
+                _ => ReportGameModeFailure(gameMode, titanfall2Api, sharp)
             };
         }
 
-        private static MpStats ReportGameModeFailure(GameMode gameMode)
+        private static MpStats ReportGameModeFailure(GameMode gameMode, Titanfall2Api titanfall2Api, ProcessSharp sharp)
         {
             var e = new ArgumentOutOfRangeException(nameof(gameMode), gameMode, $"Unknown game mode '{gameMode}'.");
             SegmentManager.SegmentManager.TrackEvent(TrackableEvent.GameplayInfoFailure, e);
-            throw e;
+            return new UnknownGameMode(titanfall2Api, sharp);
         }
 
         /// <summary>

--- a/titanfall2-rp/Titanfall2API.cs
+++ b/titanfall2-rp/Titanfall2API.cs
@@ -83,11 +83,15 @@ namespace titanfall2_rp
             return GetGameMode().ToFriendlyString();
         }
 
-        public GameMode GetGameMode()
+        public string GetGameModeCodeName()
         {
             _ensureInit();
-            string gameModeCodeName = _sharp!.Memory.Read(EngineDllBaseAddress + 0x13984088, Encoding.UTF8, 15);
-            return GameModeMethods.GetGameMode(gameModeCodeName);
+            return _sharp!.Memory.Read(EngineDllBaseAddress + 0x13984088, Encoding.UTF8, 15);
+        }
+
+        public GameMode GetGameMode()
+        {
+            return GameModeMethods.GetGameMode(GetGameModeCodeName());
         }
 
         /// <returns>the name of the multiplayer map being played</returns>

--- a/titanfall2-rp/Titanfall2API.cs
+++ b/titanfall2-rp/Titanfall2API.cs
@@ -209,7 +209,7 @@ namespace titanfall2_rp
             ServerDllBaseAddress = GetModuleBaseAddress(sharp.Native, "server.dll");
             IsNorthstarClient = System.Diagnostics.Process.GetProcessById(sharp.Native.Id)
                 .GetModules()
-                .Any(module => module.ModuleName.Equals("Northstar.dll"));
+                .Any(module => module.ModuleName?.Equals("Northstar.dll") ?? false);
         }
     }
 }

--- a/titanfall2-rp/enums/GameMode.cs
+++ b/titanfall2-rp/enums/GameMode.cs
@@ -97,6 +97,11 @@ namespace titanfall2_rp.enums
     public enum GameMode
     {
         /// <summary>
+        /// This enum value represents a game mode that is unrecognized
+        /// </summary>
+        UNKNOWN_GAME_MODE,
+
+        /// <summary>
         /// Coliseum
         /// </summary>
         coliseum,
@@ -267,9 +272,8 @@ namespace titanfall2_rp.enums
         {
             var parseSuccess = Enum.TryParse(typeof(GameMode), gameModeCodeName, true, out var mode);
             if (!parseSuccess)
-                throw new ArgumentException("Unrecognized game mode '" + gameModeCodeName + "'.");
-            return (GameMode)(mode ??
-                              throw new ArgumentException("Unrecognized game mode '" + gameModeCodeName + "'."));
+                return GameMode.UNKNOWN_GAME_MODE;
+            return (GameMode)((mode) ?? GameMode.UNKNOWN_GAME_MODE);
         }
 
         /// <summary>
@@ -314,7 +318,8 @@ namespace titanfall2_rp.enums
                 GameMode.fastball => "Fastball",
                 GameMode.hs => "Hide and Seek",
                 GameMode.ctf_comp => "Competitive CTF",
-                _ => throw new ArgumentOutOfRangeException(nameof(gameMode), gameMode, null)
+                _ => throw new ArgumentOutOfRangeException(nameof(gameMode), gameMode,
+                    "No friendly string for gamemode")
             };
         }
     }


### PR DESCRIPTION
Previously, when a user was in a gamemode that I haven't added to this, it would just say that they were still in a lobby. This was because no status update was sent to Discord. This was caused by an exception being thrown then there was an unknown gamemode. This is now handled more gracefully. Now, an unknown gamemode's codename is displayed and instead of showing the score, the text "In a match" is displayed.