### PR TITLE
🌟 Show match duration 🌟

### DIFF
--- a/titanfall2-rp/GameDetailsProvider.cs
+++ b/titanfall2-rp/GameDetailsProvider.cs
@@ -1,18 +1,16 @@
-﻿using System;
-using DiscordRPC;
+﻿using DiscordRPC;
 using titanfall2_rp.enums;
 
 namespace titanfall2_rp
 {
     public static class GameDetailsProvider
     {
-        public static (string, string, Timestamps?, Assets? assets) GetMultiplayerDetails(Titanfall2Api tf2Api,
-            DateTime gameOpenTimestamp)
+        public static (string, string, Timestamps?, Assets? assets) GetMultiplayerDetails(Titanfall2Api tf2Api)
         {
             var mpStats = tf2Api.GetMultiPlayerGameStats();
             var gameDetails = tf2Api.GetGameMode().ToFriendlyString();
             var gameState = mpStats.GetGameState();
-            var timestamps = new Timestamps(gameOpenTimestamp);
+            var timestamps = new Timestamps(mpStats.GetLastServerConnectTime());
             var map = Map.FromName(tf2Api.GetMultiplayerMapName());
             var playerInTitan = tf2Api.IsPlayerInTitan();
             var assets = new Assets

--- a/titanfall2-rp/MpStats.cs
+++ b/titanfall2-rp/MpStats.cs
@@ -302,6 +302,70 @@ namespace titanfall2_rp
                                               (Tf2Api.ClientDllBaseAddress + EntityOffsets.LocalPlayerBase)) +
                                           EntityOffsets.LocalPlayer.m_iTeamNum);
         }
+
+        /// <summary>
+        /// The current game_server_time command output. This doesn't run the command but I think I found some reliable
+        /// offsets for the value it should return.
+        ///
+        /// Currently viable offsets:
+        ///
+        /// These ones look okay. however, I don't think they're guaranteed to be right. Sometimes they just keep on ticking even though they should reset after connecting to a server.
+        /// 
+        /// tier0.g_ClockSpeedSecondsMultiplier+1E8
+        /// client.dll+C3DB28
+        /// client.dll+216FD1C
+        /// client.dll+27B8354
+        /// client.dll+27B8378
+        /// client.dll+27B837C
+        /// client.dll+27B8380
+        /// client.dll+27B8384
+        /// client.dll+27B838C
+        /// client.dll+27B8390
+        /// client.dll+27FF740
+        /// client.dll+27FF744
+        /// client.dll+27FF748
+        /// client.dll+2A9F064
+        /// client.dll+2E55F10
+        /// client.dll+3BE12A4
+        /// engine.dll+7A5C40
+        /// engine.dll+7A5C44
+        /// engine.dll+7A5C48
+        /// engine.dll+7A5C4C
+        /// engine.dll+7A5C54
+        /// engine.dll+7A5C58
+        /// engine.dll+7A6570
+        /// engine.dll+7A65FC
+        /// engine.dll+7A6748
+        /// engine.dll+7A674C
+        /// engine.dll+7B6644
+        /// engine.dll+F84BCF8
+        /// engine.dll+F84BD80
+        /// engine.dll+F84BE08
+        /// engine.dll+FD13C00
+        /// engine.dll+FD13C2C
+        /// engine.dll+FD13C58
+        ///
+        /// 
+        /// however, these ones seem to start at the right time when connecting to a match in progress from the server browser
+        /// client.dll+27FF740
+        /// client.dll+27FF744
+        /// client.dll+27FF748
+        /// client.dll+2A9F064 (this one seems to be a little ahead)
+        /// </summary>
+        /// <returns>the number of seconds since the client connected to the current server</returns>
+        public float GetServerGameTime()
+        {
+            return Sharp.Memory.Read<float>(Tf2Api.ClientDllBaseAddress + 0x27FF740);
+        }
+
+        /// <summary>
+        /// Get the timestamp of the last time the client connected to a server
+        /// </summary>
+        /// <returns>a timestamp of the last time the client connected to a server</returns>
+        public DateTime GetLastServerConnectTime()
+        {
+            return DateTimeOffset.Now.UtcDateTime.Subtract(TimeSpan.FromSeconds(GetServerGameTime()));
+        }
     }
 
     /// <summary>

--- a/titanfall2-rp/PresenceUpdateThread.cs
+++ b/titanfall2-rp/PresenceUpdateThread.cs
@@ -128,7 +128,7 @@ namespace titanfall2_rp
             else if (tf2Api.GetMultiplayerMapName().Equals("mp_lobby"))
             {
                 gameDetails = "In a lobby";
-                timestamps = new Timestamps(ProcessNetApi.StartTimestamp);
+                timestamps = new Timestamps(tf2Api.GetMultiPlayerGameStats().GetLastServerConnectTime());
             }
             else if (tf2Api.GetGameMode() == GameMode.solo)
             {
@@ -140,7 +140,7 @@ namespace titanfall2_rp
             // Besides mp_lobby, any mp map will be prefixed with mp_. Grab the specific details then!
             else if (tf2Api.GetMultiplayerMapName().StartsWith("mp_"))
             {
-                return GameDetailsProvider.GetMultiplayerDetails(tf2Api, ProcessNetApi.StartTimestamp);
+                return GameDetailsProvider.GetMultiplayerDetails(tf2Api);
             }
             // Could be main menu, might be some other random thing. This can be cleaned up later
             else


### PR DESCRIPTION
I finally found a timing-related value! Now the elapsed time will show how long you've been in your current match or lobby. Otherwise, it'll just show how long you've had the game open for.